### PR TITLE
Increase selector max specificity

### DIFF
--- a/.stylelintrc.yml
+++ b/.stylelintrc.yml
@@ -210,7 +210,7 @@ rules:
   selector-max-empty-lines: 0
   selector-max-id: 0
   selector-max-pseudo-class: 3
-  selector-max-specificity: 0,2,1
+  selector-max-specificity: 0,3,1
   selector-max-type: 0
   selector-max-universal: 1
   # DISABLED: selector-nested-pattern


### PR DESCRIPTION
Allow selectors like: `.block .element:hover`